### PR TITLE
 default to log level info plan B 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ structopt = "0.2.8"
 
 
 [features]
-default = ["log-level"]
+default = ["log-level", "verbosity", "quietness"]
 
 log-level = []
+verbosity = []
+quietness = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,14 @@ repository = "https://github.com/rust-clique/clap-verbosity-flag"
 [dependencies]
 log = "0.4.1"
 structopt = "0.2.8"
+
+
+[features]
+default = ["info"]
+
+quiet = []
+error = []
+warn = []
+info = []
+debug = []
+trace = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,6 @@ structopt = "0.2.8"
 
 
 [features]
-default = ["info"]
+default = ["log-level"]
 
-quiet = []
-error = []
-warn = []
-info = []
-debug = []
-trace = []
+log-level = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,17 @@
 extern crate log;
-#[macro_use]
 extern crate structopt;
 
 use log::Level;
+#[allow(unused)]
+use structopt::clap::{App, Arg, ArgMatches};
+use structopt::StructOpt;
+
+#[cfg(not(any(feature = "log-level", feature = "verbosity", feature = "quietness")))]
+compile_error!("at least one of the clap-verbosity-flag features needs to be enabled: `log-level`, `verbosity`, `quietness`");
 
 const DEFAULT_VERBOSITY: u8 = 3;
 
-#[cfg(feature = "log-level")]
+#[allow(unused)]
 const VERBOSITY_LEVELS: &'static [&'static str] =
     &["quiet", "error", "warn", "info", "debug", "trace"];
 
@@ -30,81 +35,105 @@ const VERBOSITY_LEVELS: &'static [&'static str] =
 /// #
 /// # fn main() {}
 /// ```
-#[derive(StructOpt, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct Verbosity {
-    /// Pass many times for less log output. see `--log-level`
-    #[cfg(feature = "log-level")]
-    #[structopt(
-        short = "q", long = "quiet", group = "clap_verbosity_flag", parse(from_occurrences)
-    )]
-    quietness: u8,
-
-    /// Pass many times for more log output. see `--log-level`
-    #[cfg(feature = "log-level")]
-    #[structopt(
-        short = "v", long = "verbose", group = "clap_verbosity_flag", parse(from_occurrences)
-    )]
-    verbosity: u8,
-
-    /// Pass many times for less log output
-    ///
-    /// By default, it'll report errors, warnings and infos.
-    /// Passing `-q` one time disables infos, `-qq` disables warnings,
-    /// `-qqq` disables errors and will print nothing,
-    #[cfg(not(feature = "log-level"))]
-    #[structopt(
-        short = "q", long = "quiet", group = "clap_verbosity_flag", parse(from_occurrences)
-    )]
-    quietness: u8,
-
-    /// Pass many times for more log output
-    ///
-    /// By default, it'll report errors, warnings and infos.
-    /// Passing `-v` one time also prints debug, `-vv` enables trace logging.
-    #[cfg(not(feature = "log-level"))]
-    #[structopt(
-        short = "v", long = "verbose", group = "clap_verbosity_flag", parse(from_occurrences)
-    )]
-    verbosity: u8,
-
-    /// Set log level. By default it is info [possible values: quiet, error,
-    /// warn, info, debug, trace]
-    ///
-    /// Alternatively It's possible to use `-v`, `-vv` to increase and `-q`,
-    /// `-qq` etc. to decrease the log level.
-    #[cfg(feature = "log-level")]
-    #[structopt(
-        long = "log-level",
-        group = "clap_verbosity_flag",
-        raw(possible_values = "VERBOSITY_LEVELS", hide_possible_values = "true")
-    )]
-    level: Option<String>,
+    level: Option<Level>,
 }
 
-impl Verbosity {
-    /// Get the log level.
-    pub fn log_level(&self) -> Option<Level> {
+impl StructOpt for Verbosity {
+    fn clap<'a, 'b>() -> App<'a, 'b> {
+        let app = App::new("clap-verbosity-flag");
+        Self::augment_clap(app)
+    }
+    fn from_clap(matches: &ArgMatches) -> Self {
+        let verbosity = DEFAULT_VERBOSITY;
+        #[cfg(feature = "quietness")]
+        let verbosity = verbosity.saturating_sub(matches.occurrences_of("quietness") as u8);
+        #[cfg(feature = "verbosity")]
+        let verbosity = verbosity.saturating_add(matches.occurrences_of("verbosity") as u8);
         #[cfg(feature = "log-level")]
-        let verbosity = if let Some(level) = self.level.as_ref() {
-            VERBOSITY_LEVELS.iter().position(|l| l == level).unwrap() as u8
+        let verbosity = if let Some(level_str) = matches.value_of("level").as_ref() {
+            VERBOSITY_LEVELS
+                .iter()
+                .position(|l| l == level_str)
+                .unwrap() as u8
         } else {
-            self.verbosity_quietness()
+            verbosity
         };
-        #[cfg(not(feature = "log-level"))]
-        let verbosity = self.verbosity_quietness();
-
-        match verbosity {
+        let level = match verbosity {
             0 => None,
             1 => Some(Level::Error),
             2 => Some(Level::Warn),
             3 => Some(Level::Info),
             4 => Some(Level::Debug),
             _ => Some(Level::Trace),
+        };
+        Verbosity { level: level }
+    }
+}
+
+impl Verbosity {
+    pub fn augment_clap<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
+        {
+            #[cfg(feature = "quietness")]
+            let app = app.arg({
+                let arg = Arg::with_name("quietness")
+                    .group("clap_verbosity_flag")
+                    .takes_value(false)
+                    .multiple(true)
+                    .short("q")
+                    .long("quiet");
+                #[cfg(feature = "log-level")]
+                let arg = arg.help("Pass many times for less log output. see `--log-level`");
+                #[cfg(not(feature = "log-level"))]
+                let arg = arg.help("Pass many times for less log output.\n\nBy default, it'll report errors, warnings and infos. Passing `-q` one time disables infos, `-qq` disables warnings, `-qqq` disables errors and will print nothing.");
+                arg
+            });
+            #[cfg(feature = "verbosity")]
+            let app = app.arg({
+                let arg = Arg::with_name("verbosity")
+                    .group("clap_verbosity_flag")
+                    .takes_value(false)
+                    .multiple(true)
+                    .short("v")
+                    .long("verbose");
+                #[cfg(feature = "log-level")]
+                let arg = arg.help("Pass many times for more log output. see `--log-level`");
+                #[cfg(not(feature = "log-level"))]
+                let arg = arg.help("Pass many times for more log output.\n\nBy default, it'll report errors, warnings and infos. Passing `-v` one time also prints debug, `-vv` enables trace logging.");
+                arg
+            });
+            #[cfg(feature = "log-level")]
+            let app = app.arg({
+                let arg = Arg::with_name("level")
+                    .group("clap_verbosity_flag")
+                    .takes_value(true)
+                    .multiple(false)
+                    .long("log-level")
+                    .possible_values(VERBOSITY_LEVELS)
+                    .hide_possible_values(true);
+                #[cfg(not(all(feature = "verbosity", feature = "quietness")))]
+                let arg = arg.help("Set log level. [default: info, possible values: quiet, error, warn, info, debug, trace]");
+                #[cfg(all(not(feature = "verbosity"), feature = "quietness"))]
+                let arg = arg.help("Set log level. [default: info, possible values: quiet, error, warn, info, debug, trace]\n\nAlternatively It\'s possible to use `-q`, `-qq` etc. to decrease the log level.");
+                #[cfg(all(feature = "verbosity", not(feature = "quietness")))]
+                let arg = arg.help("Set log level. [default: info, possible values: quiet, error, warn, info, debug, trace]\n\nAlternatively It\'s possible to use `-v`, `-vv` to increase the log level.");
+                #[cfg(all(feature = "verbosity", feature = "quietness"))]
+                let arg = arg.help("Set log level. [default: info, possible values: quiet, error, warn, info, debug, trace]\n\nAlternatively It\'s possible to use `-v`, `-vv` to increase and `-q`, `-qq` etc. to decrease the log level.");
+                arg
+            });
+            app
         }
     }
+    pub fn is_subcommand() -> bool {
+        false
+    }
+}
 
-    fn verbosity_quietness(&self) -> u8 {
-        (DEFAULT_VERBOSITY + self.verbosity).saturating_sub(self.quietness)
+impl Verbosity {
+    /// Get the log level.
+    pub fn log_level(&self) -> Option<Level> {
+        self.level
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,47 +42,36 @@ const VERBOSITY_LEVELS: &'static [&'static str] =
 /// ```
 #[derive(StructOpt, Debug, Clone)]
 pub struct Verbosity {
-    /// Pass many times for more log output
-    ///
-    /// By default, it'll report errors, warnings and infos.
-    /// Passing `-v` one time also prints debug, `-vv` enables trace logging.
-    #[cfg(not(feature = "trace"))]
-    #[structopt(short = "v", group = "clap_verbosity_flag", parse(from_occurrences))]
-    verbosity: u8,
-
-    /// Set verbosity
-    #[structopt(
-        long = "verbosity",
-        group = "clap_verbosity_flag",
-        raw(possible_values = "VERBOSITY_LEVELS"),
-        // parse(from_str = "parse_verbosity")
-    )]
-    level: Option<String>,
-
-    /// Pass many times for less log output
-    ///
-    /// By default, it'll report errors, warnings and infos.
-    /// Passing `-q` one time disables infos, `-qq` disables warnings,
-    /// `-qqq` disables errors and will print nothing,
+    /// Pass many times for less log output. see `--log-level`
     #[cfg(not(feature = "quiet"))]
-    #[structopt(short = "q", group = "clap_verbosity_flag", parse(from_occurrences))]
+    #[structopt(
+        short = "q", long = "quiet", group = "clap_verbosity_flag", parse(from_occurrences)
+    )]
     quietness: u8,
 
-    /// Disables all output
-    #[cfg(not(feature = "quiet"))]
-    #[structopt(long = "quiet", group = "clap_verbosity_flag")]
-    quiet: bool,
+    /// Pass many times for more log output. see `--log-level`
+    #[cfg(not(feature = "trace"))]
+    #[structopt(
+        short = "v", long = "verbose", group = "clap_verbosity_flag", parse(from_occurrences)
+    )]
+    verbosity: u8,
+
+    /// Set log level. By default it is info [possible values: quiet, error,
+    /// warn, info, debug, trace]
+    ///
+    /// Alternatively It's possible to use `-v`, `-vv` to increase and `-q`,
+    /// `-qq` etc. to decrease the log level.
+    #[structopt(
+        long = "log-level",
+        group = "clap_verbosity_flag",
+        raw(possible_values = "VERBOSITY_LEVELS", hide_possible_values = "true")
+    )]
+    level: Option<String>,
 }
 
 impl Verbosity {
     /// Get the log level.
     pub fn log_level(&self) -> Option<Level> {
-        #[cfg(not(feature = "quiet"))]
-        {
-            if self.quiet {
-                return None
-            }
-        }
         if let Some(level) = self.level.as_ref() {
             match level.as_ref() {
                 "quiet" => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,12 +33,35 @@ const VERBOSITY_LEVELS: &'static [&'static str] =
 #[derive(StructOpt, Debug, Clone)]
 pub struct Verbosity {
     /// Pass many times for less log output. see `--log-level`
+    #[cfg(feature = "log-level")]
     #[structopt(
         short = "q", long = "quiet", group = "clap_verbosity_flag", parse(from_occurrences)
     )]
     quietness: u8,
 
     /// Pass many times for more log output. see `--log-level`
+    #[cfg(feature = "log-level")]
+    #[structopt(
+        short = "v", long = "verbose", group = "clap_verbosity_flag", parse(from_occurrences)
+    )]
+    verbosity: u8,
+
+    /// Pass many times for less log output
+    ///
+    /// By default, it'll report errors, warnings and infos.
+    /// Passing `-q` one time disables infos, `-qq` disables warnings,
+    /// `-qqq` disables errors and will print nothing,
+    #[cfg(not(feature = "log-level"))]
+    #[structopt(
+        short = "q", long = "quiet", group = "clap_verbosity_flag", parse(from_occurrences)
+    )]
+    quietness: u8,
+
+    /// Pass many times for more log output
+    ///
+    /// By default, it'll report errors, warnings and infos.
+    /// Passing `-v` one time also prints debug, `-vv` enables trace logging.
+    #[cfg(not(feature = "log-level"))]
     #[structopt(
         short = "v", long = "verbose", group = "clap_verbosity_flag", parse(from_occurrences)
     )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
-extern crate env_logger;
-extern crate failure;
 extern crate log;
 #[macro_use]
 extern crate structopt;
 
 use log::Level;
+
+const DEFAULT_VERBOSITY: u8 = 3;
+const VERBOSITY_LEVELS: &'static [&'static str] =
+    &["quiet", "error", "warn", "info", "debug", "trace"];
 
 /// Easily add a `--verbose` flag to CLIs using Structopt
 ///
@@ -30,21 +32,57 @@ use log::Level;
 pub struct Verbosity {
     /// Pass many times for more log output
     ///
-    /// By default, it'll only report errors. Passing `-v` one time also prints
-    /// warnings, `-vv` enables info logging, `-vvv` debug, and `-vvvv` trace.
-    #[structopt(long = "verbosity", short = "v", parse(from_occurrences))]
+    /// By default, it'll report errors, warnings and infos.
+    /// Passing `-v` one time also prints debug, `-vv` enables trace logging.
+    #[structopt(short = "v", group = "clap_verbosity_flag", parse(from_occurrences))]
     verbosity: u8,
+
+    /// Set verbosity
+    #[structopt(
+        long = "verbosity",
+        group = "clap_verbosity_flag",
+        raw(possible_values = "VERBOSITY_LEVELS"),
+        // parse(from_str = "parse_verbosity")
+    )]
+    level: Option<String>,
+
+    /// Pass many times for less log output
+    ///
+    /// By default, it'll report errors, warnings and infos.
+    /// Passing `-q` one time disables infos, `-qq` disables warnings,
+    /// `-qqq` disables errors and will print nothing,
+    #[structopt(short = "q", group = "clap_verbosity_flag", parse(from_occurrences))]
+    quietness: u8,
+
+    /// Disables all output
+    #[structopt(long = "quiet", group = "clap_verbosity_flag")]
+    quiet: bool,
 }
 
 impl Verbosity {
     /// Get the log level.
-    pub fn log_level(&self) -> Level {
-        match self.verbosity {
-            0 => Level::Error,
-            1 => Level::Warn,
-            2 => Level::Info,
-            3 => Level::Debug,
-            _ => Level::Trace,
+    pub fn log_level(&self) -> Option<Level> {
+        if self.quiet {
+            None
+        } else if let Some(level) = self.level.as_ref() {
+            match level.as_ref() {
+                "quiet" => None,
+                "error" => Some(Level::Error),
+                "warn" => Some(Level::Warn),
+                "info" => Some(Level::Info),
+                "debug" => Some(Level::Debug),
+                "trace" => Some(Level::Trace),
+                _ => unreachable!(),
+            }
+        } else {
+            match (DEFAULT_VERBOSITY + self.verbosity).saturating_sub(self.quietness) {
+                0 => None,
+                1 => Some(Level::Error),
+                2 => Some(Level::Warn),
+                3 => Some(Level::Info),
+                4 => Some(Level::Debug),
+                _ => Some(Level::Trace),
+            }
         }
     }
 }
@@ -53,6 +91,14 @@ use std::fmt;
 
 impl fmt::Display for Verbosity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.verbosity)
+        let level = match self.log_level() {
+            None => 0,
+            Some(Level::Error) => 1,
+            Some(Level::Warn) => 2,
+            Some(Level::Info) => 3,
+            Some(Level::Debug) => 4,
+            Some(Level::Trace) => 5,
+        };
+        write!(f, "{}", level)
     }
 }


### PR DESCRIPTION
I saw https://github.com/rust-clique/clap-verbosity-flag/issues/10 and https://github.com/rust-clique/clap-verbosity-flag/pull/11 and have implemented another version which adds explicit `--verbosity level` and `--quiet` flags and only uses `-v` and `-q` as stackable options since i think `--verbose --verbose --verbose` looks strange but i guess `--verboser` and `--quieter` could be added as long options (then again `--verboser` looks even stranger). it might be a little confusing that `-q` and `--quiet` aren't the same.

I also made the default log level configurable. Initially I tried 
```rust
#[derive(Debug, StructOpt)]
struct Cli {
    #[structopt(flatten, default_value="info")]
    verbose: clap_verbosity_flag::Verbosity
}
```
but unfortunately that's not supported by structopt
so i opted for cargo flags.

Another shortcoming is that the help text doesn't reflect  the default log level but I wasn't sure how to achieve it without copying the whole `Verbosity` struct.

I also wasn't sure about the `--verbosity quiet` name other options would be `silent` and `none`.

I hope I could add some usable ideas to the discussion.
Manuel