### PR TITLE
fix: Don't override help strings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,8 @@ schedules:
     include:
     - master
 
-stages:
-- template: azure/stages.yml@templates
+jobs:
+- template: default.yml@templates
   parameters:
     minrust: 1.35.0
     codecov_token: $(CODECOV_TOKEN_SECRET)

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,0 +1,13 @@
+use clap_verbosity_flag::Verbosity;
+use structopt::StructOpt;
+
+/// Foo
+#[derive(Debug, StructOpt)]
+struct Cli {
+    #[structopt(flatten)]
+    verbose: Verbosity,
+}
+
+fn main() {
+    Cli::from_args();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,23 @@
+//! Easily add a `--verbose` flag to CLIs using Structopt
+//!
+//! # Examples
+//!
+//! ```rust
+//! use structopt::StructOpt;
+//! use clap_verbosity_flag::Verbosity;
+//!
+//! /// Le CLI
+//! #[derive(Debug, StructOpt)]
+//! struct Cli {
+//!     #[structopt(flatten)]
+//!     verbose: Verbosity,
+//! }
+//! #
+//! # fn main() {}
+//! ```
+
 use log::Level;
 
-/// Easily add a `--verbose` flag to CLIs using Structopt
-///
-/// # Examples
-///
-/// ```rust
-/// use structopt::StructOpt;
-/// use clap_verbosity_flag::Verbosity;
-///
-/// /// Le CLI
-/// #[derive(Debug, StructOpt)]
-/// struct Cli {
-///     #[structopt(flatten)]
-///     verbose: Verbosity,
-/// }
-/// #
-/// # fn main() {}
-/// ```
 #[derive(structopt::StructOpt, Debug, Clone)]
 pub struct Verbosity {
     /// Pass many times for more log output


### PR DESCRIPTION
strcutopt lets you define the help string via doc-comments.  Recently,
they cleaned this up which introduced a bug where a chained struct wins
out over the parent.

So moving our doc-comment to the lib to workaround it.  We should have
the majority of the documentation on the lib anyways.

Fixed #20