### PR TITLE
paw compatibility + minor improv.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ codecov = { repository = "rust-cli/clap-verbosity-flag" }
 [dependencies]
 log = "0.4.1"
 structopt = "0.3"
+paw = { version = "1.0", optional = true }
+
+[features]
+default = []
+paw-compatibility = ["paw"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,9 @@ impl Verbosity {
     /// Change the default level.
     ///
     /// `None` mans all output is disabled.
-    pub fn set_default(&mut self, level: Option<Level>) {
+    pub fn set_default(&mut self, level: Option<Level>) -> &mut Self {
         self.default = level_value(level);
+        self
     }
 
     /// Get the log level.


### PR DESCRIPTION
I had an error to use this library in combination with `structopt` + `paw`, so I added `paw` as an optional dependency behind a feature.  
Also added a minor improvement for `Verbosity::set_default`.