### PR TITLE
Add a function to instantiate a verbosity with explicit values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,14 @@ pub struct Verbosity {
 }
 
 impl Verbosity {
+    /// Create a new verbosity instance by explicitly setting the values
+    pub fn new(verbose: i8, quiet: i8, default: i8) -> Verbosity {
+        Verbosity {
+            verbose,
+            quiet,
+            default,
+        }
+    }
     /// Change the default level.
     ///
     /// `None` means all output is disabled.


### PR DESCRIPTION
I just needed a way to manually instantiate Verbosity structs for unit tests in my code. The struct fields are private so I added a `new` function