### PR TITLE
Add optional support for `tracing` besides `log`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ codecov = { repository = "rust-cli/clap-verbosity-flag" }
 [dependencies]
 log = "0.4.1"
 clap = { version = "3.0", default-features = false, features = ["std", "derive"] }
+tracing = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,14 +92,22 @@ impl<L: LogLevel> Verbosity<L> {
         }
     }
 
-    /// Get the log level.
+    /// Get the log level, as defined by the `log` crate.
     ///
     /// `None` means all output is disabled.
     pub fn log_level(&self) -> Option<log::Level> {
         level_enum(self.verbosity())
     }
 
-    /// Get the log level filter.
+    /// Get the log level, as defined by the `tracing` crate.
+    ///
+    /// `None` means all output is disabled.
+    #[cfg(feature = "tracing")]
+    pub fn tracing_level(&self) -> Option<tracing::Level> {
+        self.log_level().map(tracing_level_from_log_level)
+    }
+
+    /// Get the log level filter, as defined by the `log` crate.
     pub fn log_level_filter(&self) -> log::LevelFilter {
         level_enum(self.verbosity())
             .map(|l| l.to_level_filter())
@@ -135,6 +143,17 @@ fn level_enum(verbosity: i8) -> Option<log::Level> {
         2 => Some(log::Level::Info),
         3 => Some(log::Level::Debug),
         4..=std::i8::MAX => Some(log::Level::Trace),
+    }
+}
+
+#[cfg(feature = "tracing")]
+fn tracing_level_from_log_level(level: log::Level) -> tracing::Level {
+    match level {
+        log::Level::Error => tracing::Level::ERROR,
+        log::Level::Warn => tracing::Level::WARN,
+        log::Level::Info => tracing::Level::INFO,
+        log::Level::Debug => tracing::Level::DEBUG,
+        log::Level::Trace => tracing::Level::TRACE,
     }
 }
 


### PR DESCRIPTION
As an optional feature, add support for getting the verbosity level as
a `tracing::Level` to pass to Tokio's `tracing` library, very similar
to the existing support for getting the verbosity level as a
`log::Level`.

A `tracing` equivalent of the existing `Verbosity::log_level_filter`
method easily could be added as well:

```rust
/// Get the log level filter, as defined by the `tracing` crate.
pub fn tracing_level_filter(&self) -> tracing::level_filters::LevelFilter {
    self.tracing_level().into()
}
```

However, *that* method's body is so simple that I question whether
adding it would be worth your potentially needing to update it if
`tracing`, for example, moves the `LevelFilter` type out of that
`level_filters` module.